### PR TITLE
Multiple apps support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Add support for multiple checkout-ui apps, required for clients who have heavily edited the checkout flow
 ## [0.4.0] - 2021-07-01
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

As of this moment, this server app only fetches the first file it finds.
But if a client requires a heavily customized checkout, every development should be created separately in its own app for obvious reasons.
We now loop every setting file created as a 'vtex.checkout-ui-custom' declaration and concatenate them in a single file.

#### How to test it?

Open the console, browse `checkout6-custom.js` file. You will see, separated by declarations, all apps that export settings.
[Workspace](https://checkoutuitest--itwhirlpool.myvtex.com/checkout/#/cart)

#### How does this PR make you feel?

![](https://media.giphy.com/media/pFwRzOLfuGHok/giphy.gif)