### PR TITLE
Multiple apps support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support for multiple checkout-ui apps, required for clients who have heavily edited the checkout flow
+
 ## [0.4.1] - 2021-07-15
 
 ### Fixed

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -28,58 +28,68 @@ export async function getSettingsFromContext(ctx: Context, next: () => Promise<a
   const fileType = file.split('.').pop() === 'css' ? 'text/css' : 'text/javascript'
 
   let mdFiles: any = []
-  let settingFile = null
+  let settingFile = ''
 
-  const settingsObject = ctx.vtex.settings ? ctx.vtex.settings[0] : null
-
-  if (!settingsObject) {
+  if (!ctx.vtex.settings) {
     throw new Error(`Error getting settings from context when asking for file ${file}.`)
   }
 
-  const settingsDeclarer = removeVersionFromAppId(settingsObject.declarer)
-  const allSettingsFromDeclarer = settingsObject[settingsDeclarer]
-  settingFile = allSettingsFromDeclarer[file]
+  for (let i = 0; i < ctx.vtex.settings.length; i++) {
 
-  if (settingsDeclarer === 'vtex.checkout-ui-custom') {
-    try {
-      const field = fileType === 'text/css' ? 'cssBuild' : 'javascriptBuild'
+    const settingsObject = ctx.vtex.settings[i] ? ctx.vtex.settings[i] : null
 
-      const vbFile = await vbase.getFile('checkoutuicustom', `${workspace}-${field}`)
-        .then((res: any) => {return res.data})
-        .catch((error) => {
-          if(!error.response || error.response.status !== 404) {
-            logger.error({message: `Error retrieving VBase file ${workspace}-${field}`})
-          }
-          return null
-        })
+    const settingsDeclarer = removeVersionFromAppId(settingsObject.declarer)
+    const allSettingsFromDeclarer = settingsObject[settingsDeclarer]
 
-      if (vbFile) {
-        settingFile = parseBuffer(vbFile)
-      }
 
-      if (!vbFile) {
-        const schemas = await masterdata.getSchemas().then((res: any) => res.data)
-        if (schemas && schemas.length) {
-          mdFiles = await masterdata.searchDocuments({
-            dataEntity: DATA_ENTITY,
-            fields: [field],
-            sort: 'creationDate DESC',
-            schema: schemas.sort(function (a: any, b: any) {
-              return a.name > b.name ? -1 : 1
-            })[0].name,
-            where: `workspace=${workspace}`,
-            pagination: {
-              page: 1,
-              pageSize: 1,
-            },
+    if (settingsDeclarer === 'vtex.checkout-ui-custom') {
+      settingFile = allSettingsFromDeclarer[file]
+
+      try {
+        const field = fileType === 'text/css' ? 'cssBuild' : 'javascriptBuild'
+
+        const vbFile = await vbase.getFile('checkoutuicustom', `${workspace}-${field}`)
+          .then((res: any) => {return res.data})
+          .catch((error) => {
+            if(!error.response || error.response.status !== 404) {
+              logger.error({message: `Error retrieving VBase file ${workspace}-${field}`})
+            }
+            return null
           })
-          if (mdFiles && mdFiles.length) {
-            settingFile = mdFiles[0][field]
+
+        if (vbFile) {
+          settingFile = parseBuffer(vbFile)
+        }
+
+        if (!vbFile) {
+          const schemas = await masterdata.getSchemas().then((res: any) => res.data)
+          if (schemas && schemas.length) {
+            mdFiles = await masterdata.searchDocuments({
+              dataEntity: DATA_ENTITY,
+              fields: [field],
+              sort: 'creationDate DESC',
+              schema: schemas.sort(function (a: any, b: any) {
+                return a.name > b.name ? -1 : 1
+              })[0].name,
+              where: `workspace=${workspace}`,
+              pagination: {
+                page: 1,
+                pageSize: 1,
+              },
+            })
+            if (mdFiles && mdFiles.length) {
+              settingFile = mdFiles[0][field]
+            }
           }
         }
+      } catch (e) {
+        throw new Error(`Error getting ${file} from MD or VB.`)
       }
-    } catch (e) {
-      throw new Error(`Error getting ${file} from MD or VB.`)
+    } else {
+      settingFile += "\r\n/* source: <" + settingsDeclarer + "> */\r\n"
+      if (allSettingsFromDeclarer[file] != undefined) {
+        settingFile += allSettingsFromDeclarer[file]
+      }
     }
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -6,7 +6,7 @@
     "@types/co-body": "^5.1.0",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
-    "@vtex/api": "6.43.1",
+    "@vtex/api": "6.45.4",
     "@vtex/test-tools": "^1.0.0",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1225,10 +1225,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.43.1":
-  version "6.43.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.43.1.tgz#3c69cc23af97d23729f970b332d740041dcc8d2e"
-  integrity sha512-4I7rb+PrXGwmy/ZlYC+wQlWT9nePMdMb3dNJ9wPGMYkAa8J12uA4SeHQP9Uzf+gEYLatliTKzL1cvEYrAR41gg==
+"@vtex/api@6.45.4":
+  version "6.45.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
+  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

As of this moment, this server app only fetches the first file it finds.
But if a client requires a heavily customized checkout, every development should be created separately in its own app for obvious reasons.
We now loop every setting file created as a 'vtex.checkout-ui-custom' declaration and concatenate them in a single file.

**How to test it?**
Open the console, browse checkout6-custom.js file. You will see, separated by declarations, all apps that export settings.
https://vysk2--tiendasyabol.myvtex.com/checkout/cart/add/?sku=1440024&qty=1&seller=1&sc=1&sku=11400574&qty=1&seller=1&sc=1&sku=11400574&qty=1&seller=1&sc=1

**Credits to @Git-the-Sanz 
